### PR TITLE
fix: Fix deprecation warnings and capybara warnings

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -12,6 +12,6 @@ class Merchant < ApplicationRecord
     items.select("items.*, unit_price * count(*) AS revenue, mode() within group (order by invoices.created_at desc) AS most_sales_day")
     .left_outer_joins(invoice_items: :invoice)
     .group("items.id").
-    order("unit_price * count(*) desc").limit(5)
+    order("revenue desc").limit(5)
   end
 end

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -118,35 +118,35 @@ RSpec.describe 'merchant dashboard' do
   it 'displays items ready to ship' do
     expect(page).to have_content('Items Ready to Ship')
     within all("##{@invoice_6.id}")[0] do
-      expect(page).to have_link(@invoice_6.id)
+      expect(page).to have_link("#{@invoice_6.id}")
       expect(page).to have_content(@item_3.name)
     end
     within all("##{@invoice_6.id}")[1] do
-      expect(page).to have_link(@invoice_6.id)
+      expect(page).to have_link("#{@invoice_6.id}")
       expect(page).to have_content(@item_3.name)
     end
     within "##{@invoice_1.id}" do
-      expect(page).to have_link(@invoice_1.id)
+      expect(page).to have_link("#{@invoice_1.id}")
       expect(page).to have_content(@item_1.name)
       expect(page).to have_content(@item_5.name)
     end
     within "##{@invoice_2.id}" do
-      expect(page).to have_link(@invoice_2.id)
+      expect(page).to have_link("#{@invoice_2.id}")
       expect(page).to have_content(@item_1.name)
       expect(page).to have_content(@item_5.name)
     end
     within "##{@invoice_3.id}" do
-      expect(page).to have_link(@invoice_3.id)
+      expect(page).to have_link("#{@invoice_3.id}")
       expect(page).to have_content(@item_2.name)
       expect(page).to have_content(@item_5.name)
     end
     within "##{@invoice_4.id}" do
-      expect(page).to have_link(@invoice_4.id)
+      expect(page).to have_link("#{@invoice_4.id}")
       expect(page).to have_content(@item_4.name)
       expect(page).to have_content(@item_2.name)
     end
     within "##{@invoice_5.id}" do
-      expect(page).to have_link(@invoice_5.id)
+      expect(page).to have_link("#{@invoice_5.id}")
       expect(page).to have_content(@item_4.name)
       expect(page).to have_content(@item_3.name)
     end


### PR DESCRIPTION
Fixed the deprecation warnings we were getting and also fixed a few capybara warnings. All warnings are gone now :).