### PR TITLE
feat: Add update to invoice admin show page for status

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -6,4 +6,23 @@ class Admin::InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
   end
+
+  def update 
+    invoice = Invoice.find(params[:id])
+    invoice.update(invoice_params)
+    if (params[:invoice][:status] == "in_progress")
+      invoice.update(status: 0)
+    elsif (params[:invoice][:status] == "completed")
+      invoice.update(status: 1)
+    elsif (params[:invoice][:status] == "cancelled")
+      invoice.update(status: 2)
+    end
+    flash[:alert] = "Information Successfully Updated!"
+    redirect_to admin_invoice_path(invoice)
+  end
+
+  private 
+  def invoice_params
+    params.require(:invoice).permit(:status)
+  end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,7 +1,14 @@
 <h1>Invoice ID: <%= @invoice.id %></h1>
-<h3>Status: <%= @invoice.status %></h3>
 <h3>Created At: <%= @invoice.custom_date %></h3>
 <h3>Customer Name: <%= @invoice.customer.full_name %></h3>
+<br>
+<section id="invoice-status">
+<h3>Status: <%= @invoice.status %></h3>
+<%= form_with model: @invoice, url: admin_invoice_path(@invoice) do |form| %>
+  <%= form.select :status, ['in_progress', 'completed', 'cancelled'], selected: @invoice.status %>
+  <%= form.submit "Update" %>
+<% end %>
+</section>
 <br>
 <h2>Items: </h2>
 <ul>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -63,5 +63,31 @@ RSpec.describe 'Admin Invoices Show Page', type: :feature do
         expect(page).to have_content("Total Revenue: 1000")
       end
     end
+
+    describe 'Invoice Status Update' do
+      it "has a form to update the invoice status by selecting new status and clicking submit.
+        I am taken back to show page and see updated invoice status" do
+        visit admin_invoice_path(@invoice_1)
+        within "#invoice-status" do
+          expect(page).to have_select("invoice[status]", selected: "completed") 
+          select('in_progress', from:'invoice_status')
+          click_on 'Update'
+          expect(current_path).to eq(admin_invoice_path(@invoice_1))
+          expect(page).to have_content("Status: in_progress")
+          select('completed', from:'invoice_status')
+          click_on 'Update'
+          expect(page).to have_content("Status: completed")
+        end
+
+        visit admin_invoice_path(@invoice_2)
+        within "#invoice-status" do
+          expect(page).to have_select("invoice[status]", selected: "in_progress")
+          select('cancelled', from:'invoice_status')
+          click_on 'Update'
+          expect(current_path).to eq(admin_invoice_path(@invoice_2))
+          expect(page).to have_content("Status: cancelled")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Form for updating invoice status via a drop down menu from the admin /invoice/show page 